### PR TITLE
RSVP: Adjust P2MP ID rendering to more common hex format.

### DIFF
--- a/print-rsvp.c
+++ b/print-rsvp.c
@@ -777,7 +777,7 @@ rsvp_obj_print(netdissect_options *ndo,
             case RSVP_CTYPE_14: /* IPv6 p2mp LSP Tunnel */
                 if (obj_tlen < 26)
                     goto obj_tooshort;
-                ND_PRINT("%s  IPv6 P2MP LSP ID: 0x%08x, Tunnel ID: 0x%04x, Extended Tunnel ID: %s",
+                ND_PRINT("%s  IPv6 P2MP ID: 0x%08x, Tunnel ID: 0x%04x, Extended Tunnel ID: %s",
                        indent,
                        GET_BE_U_4(obj_tptr),
                        GET_BE_U_2(obj_tptr + 6),
@@ -788,9 +788,9 @@ rsvp_obj_print(netdissect_options *ndo,
             case RSVP_CTYPE_13: /* IPv4 p2mp LSP Tunnel */
                 if (obj_tlen < 12)
                     goto obj_tooshort;
-                ND_PRINT("%s  IPv4 P2MP LSP ID: %s, Tunnel ID: 0x%04x, Extended Tunnel ID: %s",
+                ND_PRINT("%s  IPv4 P2MP ID: 0x%08x, Tunnel ID: 0x%04x, Extended Tunnel ID: %s",
                        indent,
-                       GET_IPADDR_STRING(obj_tptr),
+                       GET_BE_U_4(obj_tptr),
                        GET_BE_U_2(obj_tptr + 6),
                        GET_IPADDR_STRING(obj_tptr + 8));
                 obj_tlen-=12;

--- a/tests/rsvp_session.out
+++ b/tests/rsvp_session.out
@@ -91,7 +91,7 @@
     1.1.1.1 > 3.3.3.3: 
 	RSVPv1 Path Message (1), Flags: [none], length: 200, ttl: 255, checksum: 0x88ac
 	  Session Object (1) Flags: [reject if unknown], Class-Type: IPv4 P2MP LSP Tunnel (13), length: 16
-	    IPv4 P2MP LSP ID: 1.49.45.0, Tunnel ID: 0x0001, Extended Tunnel ID: 1.1.1.1
+	    IPv4 P2MP ID: 0x01312d00, Tunnel ID: 0x0001, Extended Tunnel ID: 1.1.1.1
 	  RSVP Hop Object (3) Flags: [reject if unknown], Class-Type: IPv4 (1), length: 12
 	    Previous/Next Interface: 10.0.12.1, Logical Interface Handle: 0x00000000
 	  Time Values Object (5) Flags: [reject if unknown], Class-Type: 1 (1), length: 8
@@ -128,7 +128,7 @@
     10.0.12.2 > 10.0.12.1: 
 	RSVPv1 Resv Message (2), Flags: [none], length: 204, ttl: 253, checksum: 0x3483
 	  Session Object (1) Flags: [reject if unknown], Class-Type: IPv4 P2MP LSP Tunnel (13), length: 16
-	    IPv4 P2MP LSP ID: 1.49.45.0, Tunnel ID: 0x0001, Extended Tunnel ID: 1.1.1.1
+	    IPv4 P2MP ID: 0x01312d00, Tunnel ID: 0x0001, Extended Tunnel ID: 1.1.1.1
 	  RSVP Hop Object (3) Flags: [reject if unknown], Class-Type: IPv4 (1), length: 12
 	    Previous/Next Interface: 10.0.12.2, Logical Interface Handle: 0x00000000
 	  Time Values Object (5) Flags: [reject if unknown], Class-Type: 1 (1), length: 8
@@ -165,7 +165,7 @@
     10.0.12.2 > 10.0.12.1: 
 	RSVPv1 PathErr Message (3), Flags: [none], length: 72, ttl: 255, checksum: 0x21f2
 	  Session Object (1) Flags: [reject if unknown], Class-Type: IPv4 P2MP LSP Tunnel (13), length: 16
-	    IPv4 P2MP LSP ID: 1.49.45.0, Tunnel ID: 0x0001, Extended Tunnel ID: 1.1.1.1
+	    IPv4 P2MP ID: 0x01312d00, Tunnel ID: 0x0001, Extended Tunnel ID: 1.1.1.1
 	  Error Spec Object (6) Flags: [reject if unknown], Class-Type: IPv4 (1), length: 12
 	    Error Node Address: 10.0.12.2, Flags: [0x00]
 	    Error Code: Notify Error (25), Unknown Error Value (3)
@@ -180,7 +180,7 @@
     1.1.1.1 > 3.3.3.3: 
 	RSVPv1 PathTear Message (5), Flags: [none], length: 72, ttl: 255, checksum: 0x250d
 	  Session Object (1) Flags: [reject if unknown], Class-Type: IPv4 P2MP LSP Tunnel (13), length: 16
-	    IPv4 P2MP LSP ID: 1.49.45.0, Tunnel ID: 0x0001, Extended Tunnel ID: 1.1.1.1
+	    IPv4 P2MP ID: 0x01312d00, Tunnel ID: 0x0001, Extended Tunnel ID: 1.1.1.1
 	  RSVP Hop Object (3) Flags: [reject if unknown], Class-Type: IPv4 (1), length: 12
 	    Previous/Next Interface: 10.0.12.1, Logical Interface Handle: 0x00000000
 	  Sender Template Object (11) Flags: [reject if unknown], Class-Type: IPv4 P2MP LSP Tunnel (12), length: 20
@@ -194,7 +194,7 @@
     10.0.12.2 > 10.0.12.1: 
 	RSVPv1 ResvTear Message (6), Flags: [none], length: 80, ttl: 255, checksum: 0x1de8
 	  Session Object (1) Flags: [reject if unknown], Class-Type: IPv4 P2MP LSP Tunnel (13), length: 16
-	    IPv4 P2MP LSP ID: 1.49.45.0, Tunnel ID: 0x0001, Extended Tunnel ID: 1.1.1.1
+	    IPv4 P2MP ID: 0x01312d00, Tunnel ID: 0x0001, Extended Tunnel ID: 1.1.1.1
 	  RSVP Hop Object (3) Flags: [reject if unknown], Class-Type: IPv4 (1), length: 12
 	    Previous/Next Interface: 10.0.12.2, Logical Interface Handle: 0x00000000
 	  Style Object (8) Flags: [reject if unknown], Class-Type: 1 (1), length: 8


### PR DESCRIPTION
The P2MP ID is typically denoted as a single value, either in decimal or in hexadecimal format. The 4-octet notation is quite uncommon and I believe this was just a mistake in the code since the IPv6 version 11 lines above uses a hexadecimal notation instead.

I'm also using this opportunity to change the name from "P2MP LSP ID" to "P2MP ID" since that's more correct. The term "LSP ID" has a well-defined meaning in the RSVP protocol and is something else than the P2MP ID. The BGP dissector uses the term P2MP ID as well for the same value (and shows it in hexadecimal format).